### PR TITLE
Add benchmarks for SVE `fmla` instructions

### DIFF
--- a/instructionrate/Makefile
+++ b/instructionrate/Makefile
@@ -1,6 +1,12 @@
+CC := clang
+CFLAGS += -O3
 x86_instructionrate: x86_instructionrate.s x86_instructionrate.c
-	gcc -O3 x86_instructionrate.s x86_instructionrate.c -o x86_instructionrate
+	$(CC) $(CFLAGS) $^ -o $@
 arm_instructionrate: arm_instructionrate.s arm_instructionrate.c
-	gcc -O3 arm_instructionrate.s arm_instructionrate.c -o arm_instructionrate
+	$(CC) $(CFLAGS) $^ -o $@
+arm_instructionrate_sve: arm_instructionrate.s arm_instructionrate.c
+	$(CC) $(CFLAGS) -march=armv8-a+sve $^ -o $@
 x86_fusion: x86_fusion.s x86_fusion.c
-	gcc -O3 x86_fusion.s x86_fusion.c -o x86_fusion
+	$(CC) $(CFLAGS) $^ -o $@
+clean:
+	@rm -fr x86_instructionrate arm_instructionrate arm_instructionrate_sve x86_fusion 

--- a/instructionrate/arm_instructionrate.c
+++ b/instructionrate/arm_instructionrate.c
@@ -31,8 +31,10 @@ extern uint64_t latvecfadd128test(uint64_t iterations, float arr[4]);
 extern uint64_t latvecfmul128test(uint64_t iterations, float arr[4]); 
 extern uint64_t mixvecfaddfmul128test(uint64_t iterations, float arr[4]);
 extern uint64_t vecfma128test(uint64_t iterations, float arr[4]);
+extern uint64_t svefmlatest(uint64_t iterations, float arr[4]);
 extern uint64_t scalarfmatest(uint64_t iterations, float arr[4]);
 extern uint64_t latvecfma128test(uint64_t iterations, float arr[4]);
+extern uint64_t latsvefmlatest(uint64_t iterations, float arr[4]);
 extern uint64_t latscalarfmatest(uint64_t iterations, float arr[4]);
 extern uint64_t mixvecfaddfma128test(uint64_t iterations, float arr[4]);
 extern uint64_t mixvecfmulfma128test(uint64_t iterations, float arr[4]);
@@ -96,11 +98,13 @@ uint64_t vecstorewrapper(uint64_t iterations);
 uint64_t mixloadstorewrapper(uint64_t iterations);
 uint64_t mix21loadstorewrapper(uint64_t iterations);
 uint64_t vecfma128wrapper(uint64_t iterations);
+uint64_t svefmlawrapper(uint64_t iteration);
 uint64_t scalarfmawrapper(uint64_t iterations);
 uint64_t latscalarfmawrapper(uint64_t iterations);
 uint64_t mixvecfaddfma128wrapper(uint64_t iterations);
 uint64_t mixvecfmulfma128wrapper(uint64_t iterations);
 uint64_t latvecfma128wrapper(uint64_t iteration);
+uint64_t latsvefmlawrapper(uint64_t iteration);
 
 int main(int argc, char *argv[]) {
   struct timeval startTv, endTv; 
@@ -168,6 +172,8 @@ int main(int argc, char *argv[]) {
 
   printf("128-bit vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, vecfma128wrapper));
   printf("128-bit vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latvecfma128wrapper));
+  printf("SVE vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, svefmlawrapper));
+  printf("SVE vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latsvefmlawrapper));
   printf("Scalar FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, scalarfmawrapper));
   printf("Scalar FMA latency: %.2f clocks\n", 1 / measureFunction(iterationsHigh, clockSpeedGhz, latscalarfmawrapper));
   printf("1:1 mixed 128-bit vector FMA/FADD per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, mixvecfaddfma128wrapper));
@@ -298,6 +304,10 @@ uint64_t vecfma128wrapper(uint64_t iterations) {
   return vecfma128test(iterations, fpTestArr);
 }
 
+uint64_t svefmlawrapper(uint64_t iterations) {
+  return vecfma128test(iterations, fpTestArr);
+}
+
 uint64_t scalarfmawrapper(uint64_t iterations) {
   return scalarfmatest(iterations, fpTestArr);
 }
@@ -307,6 +317,10 @@ uint64_t latscalarfmawrapper(uint64_t iterations) {
 }
 
 uint64_t latvecfma128wrapper(uint64_t iterations) {
+  return latvecfma128test(iterations, fpTestArr);
+}
+
+uint64_t latsvefmlawrapper(uint64_t iterations) {
   return latvecfma128test(iterations, fpTestArr);
 }
 

--- a/instructionrate/arm_instructionrate.c
+++ b/instructionrate/arm_instructionrate.c
@@ -3,6 +3,10 @@
 #include <time.h>
 #include <stdint.h>
 
+#ifdef __ARM_FEATURE_SVE
+#include <arm_sve.h>
+#endif
+
 extern uint64_t noptest(uint64_t iterations);
 extern uint64_t clktest(uint64_t iterations); 
 
@@ -181,8 +185,8 @@ int main(int argc, char *argv[]) {
   printf("128-bit vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, vecfma128wrapper));
   printf("128-bit vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latvecfma128wrapper));
 #ifdef __ARM_FEATURE_SVE
-  printf("SVE vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, svefmawrapper));
-  printf("SVE vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latsvefmawrapper));
+  printf("%lu-bit SVE vector FMA per clk: %.2f\n", svcntw() * 32, measureFunction(iterationsHigh, clockSpeedGhz, svefmawrapper));
+  printf("%lu-bit SVE vector FMA latency: %.2f clocks\n", svcntw() * 32, 1 / measureFunction(iterations, clockSpeedGhz, latsvefmawrapper));
 #endif
   printf("Scalar FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, scalarfmawrapper));
   printf("Scalar FMA latency: %.2f clocks\n", 1 / measureFunction(iterationsHigh, clockSpeedGhz, latscalarfmawrapper));

--- a/instructionrate/arm_instructionrate.c
+++ b/instructionrate/arm_instructionrate.c
@@ -31,13 +31,17 @@ extern uint64_t latvecfadd128test(uint64_t iterations, float arr[4]);
 extern uint64_t latvecfmul128test(uint64_t iterations, float arr[4]); 
 extern uint64_t mixvecfaddfmul128test(uint64_t iterations, float arr[4]);
 extern uint64_t vecfma128test(uint64_t iterations, float arr[4]);
-extern uint64_t svefmlatest(uint64_t iterations, float arr[4]);
 extern uint64_t scalarfmatest(uint64_t iterations, float arr[4]);
 extern uint64_t latvecfma128test(uint64_t iterations, float arr[4]);
-extern uint64_t latsvefmlatest(uint64_t iterations, float arr[4]);
 extern uint64_t latscalarfmatest(uint64_t iterations, float arr[4]);
 extern uint64_t mixvecfaddfma128test(uint64_t iterations, float arr[4]);
 extern uint64_t mixvecfmulfma128test(uint64_t iterations, float arr[4]);
+
+#ifdef __ARM_FEATURE_SVE
+// Arrays of 64 floats because SVE supports up to 2048-bit wide registers
+extern uint64_t svefmatest(uint64_t iterations, float arr[64]);
+extern uint64_t latsvefmatest(uint64_t iterations, float arr[64]);
+#endif
 
 // see if SIMD pipeline shares ports with scalar ALU ones
 extern uint64_t mixaddvecadd128test(uint64_t iterations, int arr[4]);
@@ -68,6 +72,7 @@ extern uint64_t movzerotest(uint64_t iterations);
 extern uint64_t subzerotest(uint64_t iterations);
 
 float fpTestArr[4] __attribute__ ((aligned (64))) = { 0.2, 1.5, 2.7, 3.14 };
+float sveTestArr[64] __attribute__ ((aligned (64))) = { 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f, 0.2f, 1.5f, 2.7f, 3.14f };
 int intTestArr[4] __attribute__ ((aligned (64))) = { 1, 2, 3, 4 };
 int sinkArr[4] __attribute__ ((aligned (64))) = { 2, 3, 4, 5 };
 
@@ -98,13 +103,16 @@ uint64_t vecstorewrapper(uint64_t iterations);
 uint64_t mixloadstorewrapper(uint64_t iterations);
 uint64_t mix21loadstorewrapper(uint64_t iterations);
 uint64_t vecfma128wrapper(uint64_t iterations);
-uint64_t svefmlawrapper(uint64_t iteration);
 uint64_t scalarfmawrapper(uint64_t iterations);
 uint64_t latscalarfmawrapper(uint64_t iterations);
 uint64_t mixvecfaddfma128wrapper(uint64_t iterations);
 uint64_t mixvecfmulfma128wrapper(uint64_t iterations);
 uint64_t latvecfma128wrapper(uint64_t iteration);
-uint64_t latsvefmlawrapper(uint64_t iteration);
+
+#ifdef __ARM_FEATURE_SVE
+uint64_t svefmawrapper(uint64_t iterations);
+uint64_t latsvefmawrapper(uint64_t iterations);
+#endif
 
 int main(int argc, char *argv[]) {
   struct timeval startTv, endTv; 
@@ -172,8 +180,10 @@ int main(int argc, char *argv[]) {
 
   printf("128-bit vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, vecfma128wrapper));
   printf("128-bit vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latvecfma128wrapper));
-  printf("SVE vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, svefmlawrapper));
-  printf("SVE vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latsvefmlawrapper));
+#ifdef __ARM_FEATURE_SVE
+  printf("SVE vector FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, svefmawrapper));
+  printf("SVE vector FMA latency: %.2f clocks\n", 1 / measureFunction(iterations, clockSpeedGhz, latsvefmawrapper));
+#endif
   printf("Scalar FMA per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, scalarfmawrapper));
   printf("Scalar FMA latency: %.2f clocks\n", 1 / measureFunction(iterationsHigh, clockSpeedGhz, latscalarfmawrapper));
   printf("1:1 mixed 128-bit vector FMA/FADD per clk: %.2f\n", measureFunction(iterationsHigh, clockSpeedGhz, mixvecfaddfma128wrapper));
@@ -304,10 +314,6 @@ uint64_t vecfma128wrapper(uint64_t iterations) {
   return vecfma128test(iterations, fpTestArr);
 }
 
-uint64_t svefmlawrapper(uint64_t iterations) {
-  return vecfma128test(iterations, fpTestArr);
-}
-
 uint64_t scalarfmawrapper(uint64_t iterations) {
   return scalarfmatest(iterations, fpTestArr);
 }
@@ -320,9 +326,15 @@ uint64_t latvecfma128wrapper(uint64_t iterations) {
   return latvecfma128test(iterations, fpTestArr);
 }
 
-uint64_t latsvefmlawrapper(uint64_t iterations) {
-  return latvecfma128test(iterations, fpTestArr);
+#ifdef __ARM_FEATURE_SVE
+uint64_t svefmawrapper(uint64_t iterations) {
+  return svefmatest(iterations, sveTestArr);
 }
+
+uint64_t latsvefmawrapper(uint64_t iterations) {
+  return latsvefmatest(iterations, sveTestArr);
+}
+#endif
 
 uint64_t mixvecfmulfma128wrapper(uint64_t iterations) {
   return mixvecfmulfma128test(iterations, fpTestArr);

--- a/instructionrate/arm_instructionrate.s
+++ b/instructionrate/arm_instructionrate.s
@@ -38,10 +38,12 @@
 .global mixjmpvecmultest 
 .global vecfma128test
 .global latvecfma128test
-.global svefmlatest
-.global latsvefmlatest
 .global scalarfmatest
 .global latscalarfmatest
+#ifdef __ARM_FEATURE_SVE
+.global svefmatest
+.global latsvefmatest
+#endif
 
 .global mixvecfaddfma128test
 .global mixvecfmulfma128test
@@ -971,7 +973,8 @@ latvecfmul128test_loop:
   add sp, sp, #0x20
   ret 
 
-svefmlafp32test:
+#ifdef __ARM_FEATURE_SVE
+svefmatest:
   sub     sp, sp, #0x20
   stp     x14, x15, [sp, #0x10]
   mov     x14, 20
@@ -992,7 +995,7 @@ svefmlafp32test:
   mov     z29.s, s0
   mov     z30.s, s0
   mov     z31.s, s0
-svefmlafp32test_loop:
+svefmatest_loop:
   fmla    z16.s, p0/m, z16.s, z16.s
   fmla    z17.s, p0/m, z17.s, z17.s
   fmla    z18.s, p0/m, z18.s, z18.s
@@ -1009,19 +1012,27 @@ svefmlafp32test_loop:
   fmla    z29.s, p0/m, z29.s, z29.s
   fmla    z30.s, p0/m, z30.s, z30.s
   fmla    z31.s, p0/m, z31.s, z31.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z17.s, p0/m, z17.s, z17.s
+  fmla    z18.s, p0/m, z18.s, z18.s
+  fmla    z19.s, p0/m, z19.s, z19.s
   sub     x0, x0, x14
-  cbnz    x0, svefmlafp32test_loop
+  cbnz    x0, svefmatest_loop
   ldp     x14, x15, [sp, #0x10]
   add     sp, sp, #0x20
   ret
 
-latsvefmlafp32test:
+latsvefmatest:
   sub     sp, sp, #0x20
   stp     x14, x15, [sp, #0x10]
   mov     x14, 20
   ptrue   p0.s
   mov     z16.s, s0
-latsvefmlafp32test_loop:
+latsvefmatest_loop:
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
   fmla    z16.s, p0/m, z16.s, z16.s
   fmla    z16.s, p0/m, z16.s, z16.s
   fmla    z16.s, p0/m, z16.s, z16.s
@@ -1039,10 +1050,11 @@ latsvefmlafp32test_loop:
   fmla    z16.s, p0/m, z16.s, z16.s
   fmla    z16.s, p0/m, z16.s, z16.s
   sub     x0, x0, x14
-  cbnz    x0, latsvefmlafp32test_loop
+  cbnz    x0, latsvefmatest_loop
   ldp     x14, x15, [sp, #0x10]
   add     sp, sp, #0x20
   ret
+#endif
 
 mixvecfaddfmul128test:
   sub sp, sp, #0x20

--- a/instructionrate/arm_instructionrate.s
+++ b/instructionrate/arm_instructionrate.s
@@ -38,6 +38,8 @@
 .global mixjmpvecmultest 
 .global vecfma128test
 .global latvecfma128test
+.global svefmlatest
+.global latsvefmlatest
 .global scalarfmatest
 .global latscalarfmatest
 
@@ -968,6 +970,79 @@ latvecfmul128test_loop:
   ldp x14, x15, [sp, #0x10]
   add sp, sp, #0x20
   ret 
+
+svefmlafp32test:
+  sub     sp, sp, #0x20
+  stp     x14, x15, [sp, #0x10]
+  mov     x14, 20
+  ptrue   p0.s
+  mov     z16.s, s0
+  mov     z17.s, s0
+  mov     z18.s, s0
+  mov     z19.s, s0
+  mov     z20.s, s0
+  mov     z21.s, s0
+  mov     z22.s, s0
+  mov     z23.s, s0
+  mov     z24.s, s0
+  mov     z25.s, s0
+  mov     z26.s, s0
+  mov     z27.s, s0
+  mov     z28.s, s0
+  mov     z29.s, s0
+  mov     z30.s, s0
+  mov     z31.s, s0
+svefmlafp32test_loop:
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z17.s, p0/m, z17.s, z17.s
+  fmla    z18.s, p0/m, z18.s, z18.s
+  fmla    z19.s, p0/m, z19.s, z19.s
+  fmla    z20.s, p0/m, z20.s, z20.s
+  fmla    z21.s, p0/m, z21.s, z21.s
+  fmla    z22.s, p0/m, z22.s, z22.s
+  fmla    z23.s, p0/m, z23.s, z23.s
+  fmla    z24.s, p0/m, z24.s, z24.s
+  fmla    z25.s, p0/m, z25.s, z25.s
+  fmla    z26.s, p0/m, z26.s, z26.s
+  fmla    z27.s, p0/m, z27.s, z27.s
+  fmla    z28.s, p0/m, z28.s, z28.s
+  fmla    z29.s, p0/m, z29.s, z29.s
+  fmla    z30.s, p0/m, z30.s, z30.s
+  fmla    z31.s, p0/m, z31.s, z31.s
+  sub     x0, x0, x14
+  cbnz    x0, svefmlafp32test_loop
+  ldp     x14, x15, [sp, #0x10]
+  add     sp, sp, #0x20
+  ret
+
+latsvefmlafp32test:
+  sub     sp, sp, #0x20
+  stp     x14, x15, [sp, #0x10]
+  mov     x14, 20
+  ptrue   p0.s
+  mov     z16.s, s0
+latsvefmlafp32test_loop:
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  fmla    z16.s, p0/m, z16.s, z16.s
+  sub     x0, x0, x14
+  cbnz    x0, latsvefmlafp32test_loop
+  ldp     x14, x15, [sp, #0x10]
+  add     sp, sp, #0x20
+  ret
 
 mixvecfaddfmul128test:
   sub sp, sp, #0x20


### PR DESCRIPTION
This PR adds benchmarks for the throughput and latency of SVE FMA (`fmla`) instructions.

Sample results on NVIDIA Grace CPU (4x128-bit SVE):
```
SVE vector FMA per clk: 2.50
SVE vector FMA latency: 4.00 clocks
```