### PR TITLE
Update Makefile for RISC-V 64

### DIFF
--- a/InstructionRate/Makefile
+++ b/InstructionRate/Makefile
@@ -10,6 +10,9 @@ amd64:
 aarch64:
 	$(CC) $(CFLAGS) -march=native -pthread arm_instructionrate.s arm_instructionrate.c -o InstructionRate_aarch64 $(LDFLAGS)
 
+riscv64:
+	$(CC) $(CFLAGS) -march=rv64gc -pthread riscv_instructionrate.s riscv_instructionrate.c -o InstructionRate_riscv64 $(LDFLAGS)
+
 termux:
 	clang -march=armv8+aes arm_instructionrate.s arm_instructionrate.c -o InstructionRate_aarch64 $(LDFLAGS)
 
@@ -19,7 +22,7 @@ amd64_fusion:
 w64:
 	$(CC) $(CFLAGS) x86_instructionrate.c x86_instructionrate.s -o InstructionRate_w64.exe $(LDFLAGS)
 
-ci: amd64 amd64_fusion aarch64 w64
+ci: amd64 amd64_fusion aarch64 riscv64 w64
 
 clean:
 	rm -f *.o && find . -type f -executable -delete

--- a/MemoryLatency/Makefile
+++ b/MemoryLatency/Makefile
@@ -17,12 +17,18 @@ aarch64:
 aarch64-numa:
 	$(CC) $(CFLAGS) -DNUMA MemoryLatency.c MemoryLatency_arm.s -o MemoryLatency_aarch64 $(LDFLAGS) -lnuma
 
+riscv64:
+	$(CC) $(CFLAGS) MemoryLatency.c MemoryLatency_riscv.s -o MemoryLatency_riscv64 $(LDFLAGS)
+
+riscv64-numa:
+	$(CC) $(CFLAGS) -DNUMA MemoryLatency.c MemoryLatency_arm.s -o MemoryLatency_riscv64 $(LDFLAGS) -lnuma
+
 w64:
 	$(CC) $(CFLAGS) MemoryLatency.cpp MemoryLatency_x86.s -o MemoryLatency_w64.exe $(LDFLAGS)
 
 # w64 can build with mingw 11, which isn't available on jammy
 
-ci: amd64 amd64-numa aarch64 w64
+ci: amd64 amd64-numa aarch64 riscv64 w64
 
 clean:
 	rm -f *.o && find . -type f -executable -delete

--- a/MemoryLatency/Makefile
+++ b/MemoryLatency/Makefile
@@ -21,7 +21,7 @@ riscv64:
 	$(CC) $(CFLAGS) MemoryLatency.c MemoryLatency_riscv.s -o MemoryLatency_riscv64 $(LDFLAGS)
 
 riscv64-numa:
-	$(CC) $(CFLAGS) -DNUMA MemoryLatency.c MemoryLatency_arm.s -o MemoryLatency_riscv64 $(LDFLAGS) -lnuma
+	$(CC) $(CFLAGS) -DNUMA MemoryLatency.c MemoryLatency_riscv.s -o MemoryLatency_riscv64 $(LDFLAGS) -lnuma
 
 w64:
 	$(CC) $(CFLAGS) MemoryLatency.cpp MemoryLatency_x86.s -o MemoryLatency_w64.exe $(LDFLAGS)

--- a/MemoryLatency/README.md
+++ b/MemoryLatency/README.md
@@ -22,6 +22,9 @@ Run with
 ## Linux/Android+Termux, aarch64
 `gcc -O3 MemoryLatency.c MemoryLatency_arm.s -o MemoryLatency`
 
+## Linux, riscv64
+`gcc -O3 MemoryLatency.c MemoryLatency_riscv.s -o MemoryLatency`
+
 ## VS version
 Open solution and build. This is only around to hit large pages on Windows. 
 


### PR DESCRIPTION
I noticed that some microbenchmarks already provide support for RISC-V 64, but do not add the `riscv64` target to the Makefile.